### PR TITLE
bad gateway (502) seemed inappropriate

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -45,7 +45,7 @@ $content = JoshBruce\Site\Content::init(
 );
 
 if ($content->folderIsMissing()) {
-    JoshBruce\Site\Emitter::emitBadGatewayResponse(
+    JoshBruce\Site\Emitter::emitBadContentResponse(
         $markdownConverter,
         $projectRoot
     );
@@ -71,14 +71,7 @@ if ($content->notFound()) {
 }
 
 if ($server->isRequestingFile()) {
-    JoshBruce\Site\Emitter::emitWithResponseFile(
-        200,
-        [
-            'Cache-Control' => ['max-age=2592000'],
-            'Content-Type'  => $content->mimeType()
-        ],
-        $content->filePath()
-    );
+    JoshBruce\Site\Emitter::emitFile($content->mimeType(), $content->filePath());
     exit;
 }
 

--- a/setup-errors/500_2.md
+++ b/setup-errors/500_2.md
@@ -1,9 +1,9 @@
 ---
-title: Content error
+title: Server error
 usage: The folder containing the site content could not be located.
 ---
 
-# 502: Bad gateway (content)
+# 500: Server error (content)
 
 We're not sure what happened here but we're pretty sure it's on us.
 

--- a/src/Emitter.php
+++ b/src/Emitter.php
@@ -50,6 +50,18 @@ class Emitter
         $emitter->emit($response);
     }
 
+    public static function emitFile(string $mimeType, string $filePath): void
+    {
+        self::emitWithResponseFile(
+            200,
+            [
+                'Cache-Control' => ['max-age=2592000'],
+                'Content-Type'  => $mimeType
+            ],
+            $filePath
+        );
+    }
+
     public static function emitInterServerErrorResponse(
         Markdown $converter,
         string $projectRoot
@@ -98,12 +110,12 @@ class Emitter
         );
     }
 
-    public static function emitBadGatewayResponse(
+    public static function emitBadContentResponse(
         Markdown $converter,
         string $projectRoot
     ): void {
         $content = Content::init($projectRoot, 0, '/setup-errors')
-            ->for('/502.md');
+            ->for('/500.md');
 
         self::emitWithResponse(
             502,


### PR DESCRIPTION
Decided to go with internal server error (500) - may also consider 503

Also moved the file response emitter to the Emitter as a method - like the others.

This leaves `index.php` as a page controller if it makes it to the bottom of the script. If I create different types of pages, I might end up creating a controller pattern for that.

However, we don't need that at the moment. Further, I'm not sure if that will lead me to incorporating a router either.

[Describe what this PR is about]

## List of issues fixed

[Please use GitHub notation to automatically close the issues: Fixes #{issue number}]
