### PR TITLE
root check, data list, & heading permalinks

### DIFF
--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -78,6 +78,20 @@ class FileSystem
         return strlen($this->fileName()) > 0;
     }
 
+    public function isNotRoot(): bool
+    {
+        return ! $this->isRoot();
+    }
+
+    private function isRoot(): bool
+    {
+        $subtract = str_replace(
+            $this->contentRoot . '/content',
+            '',
+            $this->folderPath());
+        return strlen($subtract) === 0;
+    }
+
     private function isNotFile(): bool
     {
         return ! $this->isFile();

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -88,7 +88,8 @@ class FileSystem
         $subtract = str_replace(
             $this->contentRoot . '/content',
             '',
-            $this->folderPath());
+            $this->folderPath()
+        );
         return strlen($subtract) === 0;
     }
 

--- a/src/PageComponents/Data.php
+++ b/src/PageComponents/Data.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoshBruce\Site\PageComponents;
+
+use Carbon\Carbon;
+
+use Eightfold\HTMLBuilder\Element as HtmlElement;
+
+class Data
+{
+    /**
+     * @param array<string, mixed> $frontMatter
+     */
+    public static function create(array $frontMatter): HtmlElement|string
+    {
+        if (! array_key_exists('data', $frontMatter)) {
+            return '';
+        }
+
+        $listHeadings = [];
+        foreach ($frontMatter['data'] as $row) {
+            $label   = $row[0];
+            $current = $row[3];
+            $low     = $row[1];
+            $high    = $row[2];
+
+            $detail = 'hold';
+            if ($current > $high) {
+                $detail = 'decrease';
+
+            } elseif ($current < $low) {
+                $detail = 'increase';
+
+            }
+
+            $listHeadings[] = Htmlelement::li(
+                $label . " ({$detail})",
+                HtmlElement::ul(
+                    HtmlElement::li(
+                        HtmlElement::b('current: '),
+                        $current
+                    ),
+                    HtmlElement::li(
+                        HtmlElement::abbr('min')->props('title minimum'),
+                        ': ',
+                        $low
+                    ),
+                    HtmlElement::li(
+                        HtmlElement::abbr('max')->props('title maximum'),
+                        ': ',
+                        $high
+                    )
+                )
+            );
+        }
+        return HtmlElement::ul(...$listHeadings);
+    }
+}

--- a/src/Pages/DefaultTemplate.php
+++ b/src/Pages/DefaultTemplate.php
@@ -16,6 +16,7 @@ use JoshBruce\Site\PageComponents\Heading;
 use JoshBruce\Site\PageComponents\LogList;
 use JoshBruce\Site\PageComponents\Footer;
 use JoshBruce\Site\PageComponents\HeadElements;
+use JoshBruce\Site\PageComponents\Data;
 
 class DefaultTemplate
 {
@@ -41,7 +42,13 @@ class DefaultTemplate
     ) {
         $this->markdownConverter = $markdownConverter
             ->withConfig(['html_input' => 'allow'])
-            ->tables()->externalLinks();
+            ->externalLinks()
+            ->headingPermalinks(
+                [
+                    'min_heading_level' => 2,
+                    'symbol' => '＃'
+                ],
+            );
     }
 
     /**
@@ -57,9 +64,15 @@ class DefaultTemplate
     public function body(): string
     {
         $body = $this->markdown();
-        $body = DateBlock::create(frontMatter: $this->frontMatter()) . $body;
-        $body = Heading::create(frontMatter: $this->frontMatter()) . "\n\n" .
-            $body;
+        $body = Data::create(frontMatter: $this->frontMatter()) .
+            "\n\n" . $body;
+        $body = DateBlock::create(frontMatter: $this->frontMatter()) .
+            "\n\n" . $body;
+
+        if ($this->file->isNotRoot()) {
+            $body = Heading::create(frontMatter: $this->frontMatter()) .
+                "\n\n" . $body;
+        }
 
         $body = $body . "\n\n" . LogList::create(
             $this->frontMatter(),


### PR DESCRIPTION
Some quick changes. 

I decided to remove tables from the site as I didn't like any of the alternatives for building a table on mobile devices. Opted for a list right now until I can get around to having a table...if that ever happens.

Added the ability to check with the FileSystem instance on whether it is the root or not. (This is so I can skip displaying the header/title on the main page of the site.)

Also added permalinks for the non-h1 headings. (Funny enough this was a [feature request](https://github.com/thephpleague/commonmark/issues/519) I made on CommonMark, which was implemented.) 

## List of issues fixed

[Please use GitHub notation to automatically close the issues: Fixes #{issue number}]
