### PR TITLE
FB adds a query string to the end or URLs

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -48,6 +48,12 @@ class Server
             if (! array_key_exists($key, $this->serverGlobals)) {
                 return true;
             }
+
+            if ($key === 'REQUEST_URI') {
+                $uri = $this->serverGlobals['REQUEST_URI'];
+                $parts = explode('?', $uri);
+                $this->serverGlobals['REQUEST_URI'] = array_shift($parts);
+            }
         }
 
         if ($this->serverGlobals['APP_ENV'] !== 'production') {

--- a/tests/test-content/assets/js/javascript.js
+++ b/tests/test-content/assets/js/javascript.js
@@ -1,0 +1,1 @@
+function something() {}


### PR DESCRIPTION
Now accounted for stripping query strings out for now.

## List of issues fixed

[Please use GitHub notation to automatically close the issues: Fixes #{issue number}]
