### PR TITLE
Original content

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "8fold/commonmark-fluent-markdown",
-            "version": "0.10.0",
+            "version": "0.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/8fold/commonmark-fluent-markdown.git",
-                "reference": "cdd3b7e5064c9bd8d05ceec3d26303e6f8de6eab"
+                "reference": "fc0bb6c241da6d333a95edf51453824d327a90ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/8fold/commonmark-fluent-markdown/zipball/cdd3b7e5064c9bd8d05ceec3d26303e6f8de6eab",
-                "reference": "cdd3b7e5064c9bd8d05ceec3d26303e6f8de6eab",
+                "url": "https://api.github.com/repos/8fold/commonmark-fluent-markdown/zipball/fc0bb6c241da6d333a95edf51453824d327a90ce",
+                "reference": "fc0bb6c241da6d333a95edf51453824d327a90ce",
                 "shasum": ""
             },
             "require": {
@@ -105,7 +105,7 @@
             "description": "A fluent API for CommonMark by the PHP League",
             "support": {
                 "issues": "https://github.com/8fold/commonmark-fluent-markdown/issues",
-                "source": "https://github.com/8fold/commonmark-fluent-markdown/tree/0.10.0"
+                "source": "https://github.com/8fold/commonmark-fluent-markdown/tree/0.10.1"
             },
             "funding": [
                 {
@@ -117,7 +117,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-24T00:16:28+00:00"
+            "time": "2021-11-02T00:21:47+00:00"
         },
         {
             "name": "8fold/php-html-builder",

--- a/public/index.php
+++ b/public/index.php
@@ -13,7 +13,7 @@ require $projectRoot . '/vendor/autoload.php';
  * Regardless of what happens next, we'll need a baseline markdown converter.
  */
 $markdownConverter = Eightfold\Markdown\Markdown::create()
-    ->minified()
+    ->minified() // can't be minified due to code blocks
     ->smartPunctuation();
 
 // Inject environment variables to global $_SERVER array

--- a/src/PageComponents/DateBlock.php
+++ b/src/PageComponents/DateBlock.php
@@ -38,6 +38,9 @@ class DateBlock
             ->props('is dateblock')->build();
     }
 
+    /**
+     * @param array<string, mixed> $frontMatter
+     */
     private static function timestamp(
         array $frontMatter,
         string $key,

--- a/src/PageComponents/DateBlock.php
+++ b/src/PageComponents/DateBlock.php
@@ -15,36 +15,46 @@ class DateBlock
      */
     public static function create(array $frontMatter): string
     {
-        $updated = '';
-        if (
-            array_key_exists('updated', $frontMatter) and
-            $carbon = Carbon::createFromFormat('Ymd', $frontMatter['updated'])
-        ) {
-            $time = HtmlElement::time($carbon->toFormattedDateString())
-                ->props(
-                    'property dateModified',
-                    'content ' . $carbon->format('Y-m-d')
-                )->build();
-            $updated = HtmlElement::p("Updated on: {$time}");
-        }
+        $created = self::timestamp(
+            $frontMatter,
+            'created',
+            'Created on',
+            'dateCreated'
+        );
 
-        $created = '';
-        if (
-            array_key_exists('created', $frontMatter) and
-            $carbon = Carbon::createFromFormat('Ymd', $frontMatter['created'])
-        ) {
-            $time = HtmlElement::time($carbon->toFormattedDateString())
-                ->props(
-                    'property dateCreated',
-                    'content ' . $carbon->format('Y-m-d')
-                )->build();
-            $created = HtmlElement::p("Created on: {$time}");
-        }
+        $moved = self::timestamp($frontMatter, 'moved', 'Moved on');
 
-        if (empty($updated) and empty($created)) {
+        $updated = self::timestamp(
+            $frontMatter,
+            'updated',
+            'Updated on',
+            'dateModified'
+        );
+
+        if (empty($updated) and empty($moved) and empty($created)) {
             return '';
         }
-        return HtmlElement::div($created, $updated)
+        return HtmlElement::div($created, $moved, $updated)
             ->props('is dateblock')->build();
+    }
+
+    private static function timestamp(
+        array $frontMatter,
+        string $key,
+        string $label,
+        string $schemaProp = ''
+    ): HtmlElement|string {
+        if (
+            array_key_exists($key, $frontMatter) and
+            $carbon = Carbon::createFromFormat('Ymd', $frontMatter[$key])
+        ) {
+            $time = HtmlElement::time($carbon->toFormattedDateString())
+                ->props(
+                    (strlen($schemaProp) > 0) ? "property {$schemaProp}" : '',
+                    'content ' . $carbon->format('Y-m-d')
+                )->build();
+            return HtmlElement::p("{$label}: {$time}");
+        }
+        return '';
     }
 }

--- a/src/PageComponents/OriginalContentNotice.php
+++ b/src/PageComponents/OriginalContentNotice.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoshBruce\Site\PageComponents;
+
+use Eightfold\Markdown\Markdown;
+
+use Eightfold\HTMLBuilder\Element as HtmlElement;
+
+use JoshBruce\Site\FileSystem;
+use JoshBruce\Site\Content;
+
+class OriginalContentNotice
+{
+    /**
+     * @param array<string, mixed> $frontMatter
+     */
+    public static function create(
+        array $frontMatter,
+        Markdown $markdownConverter,
+        FileSystem $fileSystem
+    ): string {
+        $file = $fileSystem->with('/messages', 'original.md');
+        if (
+            array_key_exists('original', $frontMatter) and
+            $file->found() and
+            $markdown = Content::init($file)->markdown()
+        ) {
+            list($link, $platform) = explode(' ', $frontMatter['original'], 2);
+            $originalLink = "[{$platform}]({$link})";
+            $markdown = str_replace(
+                '{{platform link}}',
+                $originalLink,
+                $markdown
+            );
+
+            return $markdown;
+        }
+        return '';
+    }
+}

--- a/src/Pages/DefaultTemplate.php
+++ b/src/Pages/DefaultTemplate.php
@@ -10,13 +10,14 @@ use Eightfold\HTMLBuilder\Document;
 
 use JoshBruce\Site\FileSystem;
 use JoshBruce\Site\Content;
-use JoshBruce\Site\PageComponents\Navigation;
+use JoshBruce\Site\PageComponents\Data;
 use JoshBruce\Site\PageComponents\DateBlock;
-use JoshBruce\Site\PageComponents\Heading;
-use JoshBruce\Site\PageComponents\LogList;
 use JoshBruce\Site\PageComponents\Footer;
 use JoshBruce\Site\PageComponents\HeadElements;
-use JoshBruce\Site\PageComponents\Data;
+use JoshBruce\Site\PageComponents\Heading;
+use JoshBruce\Site\PageComponents\LogList;
+use JoshBruce\Site\PageComponents\Navigation;
+use JoshBruce\Site\PageComponents\OriginalContentNotice;
 
 class DefaultTemplate
 {
@@ -42,9 +43,10 @@ class DefaultTemplate
     ) {
         $this->markdownConverter = $markdownConverter
             ->withConfig(['html_input' => 'allow'])
-            ->externalLinks()
             ->abbreviations()
-            ->headingPermalinks(
+            ->externalLinks([
+                'open_in_new_window' => true
+            ])->headingPermalinks(
                 [
                     'min_heading_level' => 2,
                     'symbol' => '＃'
@@ -67,8 +69,18 @@ class DefaultTemplate
         $body = $this->markdown();
         $body = Data::create(frontMatter: $this->frontMatter()) .
             "\n\n" . $body;
+
+        $originalLink = OriginalContentNotice::create(
+            frontMatter: $this->frontMatter(),
+            fileSystem: $this->file,
+            markdownConverter: $this->markdownConverter
+        );
+        $body = $originalLink . "\n\n" . $body;
+
         $body = DateBlock::create(frontMatter: $this->frontMatter()) .
             "\n\n" . $body;
+
+
 
         if ($this->file->isNotRoot()) {
             $body = Heading::create(frontMatter: $this->frontMatter()) .


### PR DESCRIPTION
- Fixed code block issue with update to Fluent Markdown library
- Updated DateBlock for `moved` parameter
- Added OriginalContentNotice for letting folks know the content was moved from a different platform
- Made it so external links with open in new tab/window

## List of issues fixed

[Please use GitHub notation to automatically close the issues: Fixes #{issue number}]
