### PR TITLE
BREAKING CHANGE: move status code primary logic to request

### DIFF
--- a/src/HttpRequest.php
+++ b/src/HttpRequest.php
@@ -52,12 +52,22 @@ class HttpRequest
         }
     }
 
-    public function isMissingRequiredValues(): bool
+    public function statusCode(): int
     {
-        return $this->serverGlobals()->isMissingRequiredValues();
+        if ($this->serverGlobals()->isMissingRequiredValues()) {
+            return 500;
+
+        } elseif ($this->isUnsupportedMethod()) {
+            return 405;
+
+        } elseif ($this->isNotFound()) {
+            return 404;
+
+        }
+        return 200;
     }
 
-    public function isUnsupportedMethod(): bool
+    private function isUnsupportedMethod(): bool
     {
         $requestMethod = strtoupper($this->psrRequest()->getMethod());
         $isSupported   =  in_array($requestMethod, $this->supportedMethods());
@@ -65,7 +75,7 @@ class HttpRequest
         return ! $isSupported;
     }
 
-    public function isNotFound(): bool
+    private function isNotFound(): bool
     {
         $isFound = file_exists($this->localPath()) and
             is_file($this->localPath());

--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -37,17 +37,7 @@ class HttpResponse
 
     public function statusCode(): int
     {
-        if ($this->request()->isMissingRequiredValues()) {
-            return 500;
-
-        } elseif ($this->request()->isUnsupportedMethod()) {
-            return 405;
-
-        } elseif ($this->request()->isNotFound()) {
-            return 404;
-
-        }
-        return 200;
+        return $this->request()->statusCode();
     }
 
     /**


### PR DESCRIPTION
status code in the response only checked against information the request had; therefore, moved the logic to the request and marked some isUnsopportedMethod and isNotFound private

[Describe what this PR is about]

## List of issues fixed

[Please use GitHub notation to automatically close the issues: Fixes #{issue number}]
