### PR TITLE
fix: LogList.php no redirect

### DIFF
--- a/site-dynamic-php/src/DocumentComponents/LogList.php
+++ b/site-dynamic-php/src/DocumentComponents/LogList.php
@@ -37,6 +37,9 @@ class LogList
 
             $title = $f->title();
             $href  = $f->canonicalUrl($environment->appUrl());
+            if (! str_ends_with($href, '/')) {
+                $href = $href . '/';
+            }
 
             $key = $f->path(full: false, omitFilename: true);
 


### PR DESCRIPTION
Links didn't end in forward slash. Therefore, would cause redirect on click.

## List of issues fixed

[Please use GitHub notation to automatically close the issues: Fixes #{issue number}]
